### PR TITLE
fix: `lazy()` and `repeat()` test

### DIFF
--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -413,6 +413,7 @@ test("repeat works with complex patterns", () => {
 });
 
 test("throws error when making empty pattern lazy", () => {
+  // @ts-expect-error: Cannot call .lazy() on an empty pattern.
   expect(() => createRegex().lazy()).toThrow("No quantifier to make lazy");
 });
 
@@ -540,5 +541,6 @@ test("throws error for invalid Unicode letter variant", () => {
 });
 
 test("throws error when no pattern is available to repeat", () => {
+  // @ts-expect-error: Cannot call .repeat(3) on an empty pattern.
   expect(() => createRegex().repeat(3)).toThrow("No pattern to repeat");
 });


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

This PR updates our tests for the `.lazy()` and `.repeat(3)` methods. Since our API design prevents these methods from being called on an empty pattern via TypeScript’s type system, we no longer test for a runtime error. Instead, we now use the `@ts-expect-error` directive to assert that these method calls are disallowed at compile time.

Fixes # (issue)

## 🔍 Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 📝 Documentation update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further Comments

The tests now include the following:

```ts
// @ts-expect-error: Cannot call .lazy() on an empty pattern.
createRegex().lazy();

// @ts-expect-error: Cannot call .repeat(3) on an empty pattern.
createRegex().repeat(3);
```

This ensures that our type definitions are correctly preventing misuse of these methods, aligning the tests with our intended API behavior.