### PR TITLE
fix(package): add exports map for proper dual-module support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "exports": {
     ".": {
       "import": "./dist/human-regex.esm.js",
-      "require": "./dist/human-regex.cjs.js"
+      "require": "./dist/human-regex.cjs.js",
+      "types": "./index.d.ts"
     }
   },
-  "types": "types/index.d.ts",
+  "types": "./index.d.ts",
   "type": "module",
   "scripts": {
     "test": "jest --coverage",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "Human-friendly regex builder with English-like syntax",
   "main": "dist/human-regex.cjs.js",
   "module": "dist/human-regex.esm.js",
+  "exports": {
+    ".": {
+      "import": "./dist/human-regex.esm.js",
+      "require": "./dist/human-regex.cjs.js"
+    }
+  },
   "types": "types/index.d.ts",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

The package currently uses `"type": "module"` along with the legacy "main" and "module" fields. This combination leads to ambiguous module resolution in modern ESM-first environments (like Vite, Vitest, and Node.js itself), causing import errors for consumers.

This commit introduces the "exports" field to package.json. This provides an explicit, standardized map that tells the Node.js ecosystem which file to use for CommonJS (`require`) and which to use for ES Modules (`import`).

This change resolves the loading errors and allows the package to be consumed seamlessly in all project types without requiring downstream workarounds.

Fixes #20

## 🔍 Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [n/a] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [n/a] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
