### PR TITLE
feat: cross-platform new line helper `newline()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Creates a new regex builder instance.
 | `.anyCharacter()`    | Adds a pattern for any character (`.`).         | `.`            |
 | `.literal("text")`   | Adds a literal text pattern.                    | `["text"]`     |
 | `.or()`              | Adds an OR pattern.                             | `\|`           |
+| `.newline()`         | Adds a pattern for newline characters.          | `(\r\n\|\r\|\n)` |
 | `.range("digit")`    | Adds a range pattern for digits (`0-9`).        | `[0-9]`        |
 | `.notRange("aeiou")` | Excludes characters from the pattern.           | `[^aeiou]`     |
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,7 @@ export class HumanRegex {
   lazy(): Base;
   letter(): Base;
   anyCharacter(): Base;
+  newline(): Base;
 
   // Lookahead/behind
   negativeLookahead(pattern: string): Base;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-regex",
-  "version": "2.0.0",
+  "version": "2.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-regex",
-      "version": "2.0.0",
+      "version": "2.1.5",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"
@@ -26,6 +26,10 @@
         "rollup": "^4.34.0",
         "ts-jest": "^29.2.5",
         "typescript": "^5.7.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rajibola"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/src/human-regex.ts
+++ b/src/human-regex.ts
@@ -106,6 +106,10 @@ class HumanRegex {
     return this.add(".");
   }
 
+  newline(): Base {
+    return this.add("(\\r\\n|\\r|\\n)"); // Windows: \r\n, Unix: \n, Old Macs: \r
+  }
+
   negativeLookahead(pattern: string): Base {
     return this.add(`(?!${pattern})`);
   }

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -544,3 +544,11 @@ test("throws error when no pattern is available to repeat", () => {
   // @ts-expect-error: Cannot call .repeat(3) on an empty pattern.
   expect(() => createRegex().repeat(3)).toThrow("No pattern to repeat");
 });
+
+test("expect newline(s) to be detected properly", () => {
+  const regex = createRegex().newline().toRegExp();
+  expect(regex.test("\n")).toBe(true);
+  expect(regex.test(`first line
+second line`)).toBe(true);
+  expect(regex.test("test")).toBe(false);
+});


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

There is at the moment no way to add escape sequences as `literal()` will escape characters. One of them is `\n` in Unix or its equivalent on Windows and old Macs. This PR introduces a new helper `newline()` corresponding to the regex `(\r\n|\r|\n)`. 

Fixes #19

## 🔍 Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## 💬 Further Comments

Other PRs should be considered, at least for the `\t` new tab.
