### PR TITLE
feat!: custom range inclusion `anyOf()` and exclusion `notAnyOf()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ Creates a new regex builder instance.
 | `.literal("text")`   | Adds a literal text pattern.                    | `["text"]`     |
 | `.or()`              | Adds an OR pattern.                             | `\|`           |
 | `.range("digit")`    | Adds a range pattern for digits (`0-9`).        | `[0-9]`        |
-| `.notRange("aeiou")` | Excludes characters from the pattern.           | `[^aeiou]`     |
+| `.notRange("letter")` | Adds a range pattern for non-letters           | `[^a-zA-Z]`     |
+| `.anyOf("aeiou\\s")`    | Adds list of accepted characters          | `[aeiou\s]`     |
+| `.notAnyOf("aeiou\\s")` | Adds list of excluded characters          | `[^aeiou\s]`     |
+
+
 
 ### Quantifiers
 
@@ -164,6 +168,26 @@ Creates a new regex builder instance.
 - `Patterns.email`: Predefined email pattern.
 - `Patterns.url`: Predefined URL pattern.
 - `Patterns.phoneInternational`: Predefined international phone number pattern.
+
+### Predefined Ranges
+
+For use with `range()` and `notRange()`:
+
+  digit: "0-9",
+  lowercaseLetter: "a-z",
+  uppercaseLetter: "A-Z",
+  letter: "a-zA-Z",
+  alphanumeric: "a-zA-Z0-9",
+  anyCharacter: ".",
+
+| RangeKey                  | Range value    |
+| ------------------------ | --------------- | 
+| `digit`                  | `0-9`           | 
+| `lowercaseLetter`        | `a-z`           | 
+| `uppercaseLetter`        | `A-Z`           |
+| `letter`                 | `a-zA-Z`        | 
+| `alphanumeric`           | `a-zA-Z0-9`     | 
+| `anyCharacter`           | `.`             | 
 
 ## Examples
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,9 @@ export class HumanRegex {
   or(): AfterAnchor;
 
   range(name: RangeKeys): Base;
-  notRange(chars: string): Base;
+  notRange(name: RangeKeys): Base;
+  anyOf(chars: string): Base;
+  notAnyOf(chars: string): Base;
   lazy(): Base;
   letter(): Base;
   anyCharacter(): Base;

--- a/src/human-regex.ts
+++ b/src/human-regex.ts
@@ -88,7 +88,17 @@ class HumanRegex {
     return this.add(`[${range}]`);
   }
 
-  notRange(chars: string): Base {
+  notRange(name: RangeKeys): Base {
+    const range = Ranges[name];
+    if (!range) throw new Error(`Unknown range: ${name}`);
+    return this.add(`[^${range}]`);
+  }
+
+  anyOf(chars: string): Base {
+    return this.add(`[${chars}]`);
+  }
+
+  notAnyOf(chars: string): Base {
     return this.add(`[^${chars}]`);
   }
 

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -186,6 +186,17 @@ test("range method works correctly", () => {
   expect(letterRegex.test("5")).toBe(false);
 });
 
+test("notRange method works correctly", () => {
+  const regex = createRegex().notRange("digit").toRegExp();
+  expect(regex.test("5")).toBe(false);
+  expect(regex.test("a")).toBe(true);
+
+  const letterRegex = createRegex().notRange("letter").toRegExp();
+  expect(letterRegex.test("a")).toBe(false);
+  expect(letterRegex.test("Z")).toBe(false);
+  expect(letterRegex.test("5")).toBe(true);
+});
+
 test("or method works correctly", () => {
   const regex = createRegex().literal("cat").or().literal("dog").toRegExp();
   expect(regex.test("cat")).toBe(true);
@@ -340,10 +351,18 @@ test("wordBoundary works correctly", () => {
   expect(regex.test("atest")).toBe(false);
 });
 
-test("notRange excludes specified characters", () => {
-  const regex = createRegex().notRange("aeiou").toRegExp();
+test("anyOf detects specified characters", () => {
+  const regex = createRegex().anyOf("aeiou\\s").toRegExp();
+  expect(regex.test("b")).toBe(false);
+  expect(regex.test("a")).toBe(true);
+  expect(regex.test(" ")).toBe(true);
+});
+
+test("notAnyOf excludes specified characters", () => {
+  const regex = createRegex().notAnyOf("aeiou\\s").toRegExp();
   expect(regex.test("b")).toBe(true);
   expect(regex.test("a")).toBe(false);
+  expect(regex.test(" ")).toBe(false);
 });
 
 test("zeroOrMore works correctly", () => {

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -186,6 +186,13 @@ test("range method works correctly", () => {
   expect(letterRegex.test("5")).toBe(false);
 });
 
+test("range and notRange methods only handle known range presets", () => {
+  // @ts-expect-error: "somerange" not in RangeKeys
+  expect(() => createRegex().range("somerange")).toThrow("Unknown range: somerange")
+// @ts-expect-error: "somerange" not in RangeKeys
+  expect(() => createRegex().notRange("somerange")).toThrow("Unknown range: somerange")
+})
+
 test("notRange method works correctly", () => {
   const regex = createRegex().notRange("digit").toRegExp();
   expect(regex.test("5")).toBe(false);


### PR DESCRIPTION
# 🚀 Pull Request

## 📋 Description

- Introduces `anyOf()` method to include a custom range of characters`
- Introduces a `notRange()` method to exclude a preset range, i.e. the opposite of `range()`
- ⚠️ BREAKING CHANGE: renames `notRange()` to `notAnyOf()` 
- Also increases test coverage by adding test for `range()` and `notRange()` throwing an error on an unknown range

Fixes #23 

## 🔍 Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update

## ✅ Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
