### PR TITLE
feat: implement missing .regex() method and fix .repeat() capture-group shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- TEMPLATE: copy the sections below into a new entry and replace the bracketed placeholders. -->
+
 ### Added
 
 - [Brief description of new features]
@@ -30,6 +32,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - [Security-related updates]
+
+<!-- Current update -->
+
+### Added
+
+- `regex(input)` method to splice an existing `RegExp` or pattern string into the
+  chain. Flags from a passed `RegExp` are merged, and an invalid pattern string
+  throws a descriptive error pointing to `.literal()`.
+
+### Fixed
+
+- Implemented the previously-documented `.regex()` method, which was referenced in
+  the README, advanced usage, and FAQ but never existed and threw
+  `TypeError: createRegex(...).regex is not a function` at runtime.
+
+### Contributors
+
+- Hammed Abdulazeez (@lurdharry)
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- TEMPLATE: copy the sections below into a new entry and replace the bracketed placeholders. -->
-
 ### Added
 
 - [Brief description of new features]
@@ -33,8 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [Security-related updates]
 
-<!-- Current update -->
-
 ### Added
 
 - `regex(input)` method to splice an existing `RegExp` or pattern string into the
@@ -46,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implemented the previously-documented `.regex()` method, which was referenced in
   the README, advanced usage, and FAQ but never existed and threw
   `TypeError: createRegex(...).regex is not a function` at runtime.
+- `.repeat(count)` now wraps the repeated pattern in a non-capturing group
+  (`(?:...)`) instead of a capturing one, so it no longer shifts the numbering of
+  the user's own capture groups.
 
 ### Contributors
 
@@ -65,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dual module support for CommonJS and ES Modules.
 
 ### Contributors
+
 - Thomas Lamant (@tmlmt)
 
 ---

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Creates a new regex builder instance.
 | `.nonWhitespace()`   | Adds a non-whitespace character pattern (`\S`). | `\S`           |
 | `.anyCharacter()`    | Adds a pattern for any character (`.`).         | `.`            |
 | `.literal("text")`   | Adds a literal text pattern.                    | `["text"]`     |
+| `.regex(input)`      | Splices an existing `RegExp`/pattern string in. | `^[A-Z]`       |
 | `.or()`              | Adds an OR pattern.                             | `\|`           |
 | `.newline()`         | Adds a pattern for newline characters.          | `(\r\n\|\r\|\n)` |
 | `.range("digit")`    | Adds a range pattern for digits (`0-9`).        | `[0-9]`        |

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -2,9 +2,23 @@
 
 ## Combining with Existing Regex
 
+Use `.regex()` to splice a pattern you already have into the chain. It accepts a
+`RegExp` or a raw pattern string, and merges any flags from a passed `RegExp`.
+
 ```javascript
 const basePattern = /^[A-Z]/;
 const combined = createRegex().regex(basePattern).digit().exactly(3).toRegExp();
+// /^[A-Z]\d{3}/
+```
+
+The input is treated as a **regex pattern**, not literal text — so `.` , `*`, `(`
+and other metacharacters keep their regex meaning. If you want to match text
+literally, use `.literal()` instead. Passing an invalid pattern string throws a
+descriptive error at the call site rather than later at `.toRegExp()`:
+
+```javascript
+createRegex().regex("("); // throws: Invalid regex pattern passed to .regex(): "(" ...
+createRegex().literal("("); // matches a literal "(" character
 ```
 
 ## Lookaheads/Lookbehinds

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -5,7 +5,24 @@
 ```javascript
 .digit()       // Matches any digit (0-9)
 .word()        // Matches word character (a-z, A-Z, 0-9, _)
-.literal(text) // Matches exact text string
+.literal(text) // Matches exact text string (special characters are escaped)
+.regex(input)  // Splices an existing RegExp or pattern string into the chain
+```
+
+### `.regex(input: RegExp | string)`
+
+Inserts an existing pattern into the chain, verbatim. Use this to reuse a regex
+you already have rather than rebuilding it.
+
+- Accepts a `RegExp` (e.g. `/^[A-Z]/`) or a raw pattern string (e.g. `"[A-Z]"`).
+- When given a `RegExp`, its flags (`g`, `i`, …) are merged into the builder.
+- The input is treated as a **pattern**, so metacharacters keep their regex
+  meaning. To match text literally instead, use `.literal()`.
+- If a string is not a valid regex pattern, `.regex()` throws immediately with a
+  message pointing you to `.literal()`.
+
+```javascript
+createRegex().regex(/^[A-Z]/).digit().exactly(3).toRegExp(); // /^[A-Z]\d{3}/
 ```
 
 ## Quantifiers

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -6,7 +6,17 @@ A: Use `.literal('\\$')` to match $ symbol
 
 ## Q: Can I use existing regex patterns?
 
-A: Yes! Use `.regex(/existing-pattern/)` method
+A: Yes! Use the `.regex(/existing-pattern/)` method. It also accepts a raw
+pattern string and merges any flags from a passed `RegExp`.
+
+Note that `.regex()` treats its input as a **pattern**, so characters like `.`,
+`*`, and `(` act as regex metacharacters. If you instead want to match those
+characters as plain text, use `.literal()`:
+
+```javascript
+createRegex().regex("a.b"); // "." matches ANY character → matches "axb", "a.b", ...
+createRegex().literal("a.b"); // "." is escaped → matches only the exact text "a.b"
+```
 
 ## Q: How to make case-insensitive matches?
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -60,6 +60,7 @@ export class HumanRegex {
   whitespace(): Base;
   nonWhitespace(): Base;
   literal(text: string): this;
+  regex(input: RegExp | string): Base;
   or(): AfterAnchor;
 
   range(name: RangeKeys): Base;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "human-regex",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "human-regex",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
     {
       "name": "Marlon Evangelista",
       "url": "https://github.com/MForMarlon"
+    },
+    {
+      "name": "Hammed Abdulazeez",
+      "url": "https://github.com/lurdharry"
     }
   ],
   "license": "MIT",

--- a/src/human-regex.ts
+++ b/src/human-regex.ts
@@ -78,6 +78,23 @@ class HumanRegex {
     return this.add(escapeLiteral(text));
   }
 
+  regex(input: RegExp | string): Base {
+    if (input instanceof RegExp) {
+      for (const flag of input.flags) this.flags.add(flag);
+      return this.add(input.source);
+    }
+
+    try {
+      new RegExp(input);
+    } catch {
+      throw new Error(
+        `Invalid regex pattern passed to .regex(): "${input}". ` +
+          `If you meant to match this text literally, use .literal() instead.`
+      );
+    }
+    return this.add(input);
+  }
+
   or(): AfterAnchor {
     return this.add("|");
   }

--- a/src/human-regex.ts
+++ b/src/human-regex.ts
@@ -282,7 +282,7 @@ class HumanRegex {
     }
 
     const lastPart = this.parts.pop();
-    this.parts.push(`(${lastPart}){${count}}`);
+    this.parts.push(`(?:${lastPart}){${count}}`);
     return this;
   }
 

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -578,3 +578,41 @@ test("expect newline(s) to be detected properly", () => {
 second line`)).toBe(true);
   expect(regex.test("test")).toBe(false);
 });
+
+test("regex method splices an existing RegExp into the chain", () => {
+  const basePattern = /^[A-Z]/;
+  const regex = createRegex().regex(basePattern).digit().exactly(3).toRegExp();
+  expect(regex.source).toBe("^[A-Z]\\d{3}");
+  expect(regex.test("A123")).toBe(true);
+  expect(regex.test("a123")).toBe(false);
+  expect(regex.test("A12")).toBe(false);
+});
+
+test("regex method accepts a raw string pattern", () => {
+  const regex = createRegex().regex("[A-Z]").digit().exactly(2).toRegExp();
+  expect(regex.source).toBe("[A-Z]\\d{2}");
+  expect(regex.test("A12")).toBe(true);
+});
+
+test("regex method merges flags from the provided RegExp", () => {
+  const regex = createRegex().regex(/abc/gi).toRegExp();
+  expect(regex.flags).toContain("g");
+  expect(regex.flags).toContain("i");
+});
+
+test("regex method throws a helpful error for an invalid pattern string", () => {
+  expect(() => createRegex().regex("(")).toThrow(
+    'Invalid regex pattern passed to .regex(): "(". If you meant to match this text literally, use .literal() instead.',
+  );
+  expect(() => createRegex().regex("[a")).toThrow(
+    'Invalid regex pattern passed to .regex(): "[a". If you meant to match this text literally, use .literal() instead.',
+  );
+  expect(() => createRegex().regex("*")).toThrow(
+    'Invalid regex pattern passed to .regex(): "*". If you meant to match this text literally, use .literal() instead.',
+  );
+});
+
+test("regex method allows ordinary text that is a valid pattern", () => {
+  const regex = createRegex().regex("hello").toRegExp();
+  expect(regex.test("hello")).toBe(true);
+});

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -616,3 +616,21 @@ test("regex method allows ordinary text that is a valid pattern", () => {
   const regex = createRegex().regex("hello").toRegExp();
   expect(regex.test("hello")).toBe(true);
 });
+
+test("repeat uses a non-capturing group so it does not shift capture indices", () => {
+  const regex = createRegex()
+    .digit()
+    .repeat(2)
+    .startCaptureGroup()
+    .letter()
+    .oneOrMore()
+    .endGroup()
+    .toRegExp();
+
+  // repeat must not create its own capture group
+  expect(regex.source).toBe("(?:\\d){2}([a-zA-Z]+)");
+
+  // the user's group stays at index 1
+  const match = "12ab".match(regex);
+  expect(match?.[1]).toBe("ab");
+});


### PR DESCRIPTION
This PR contains two related fixes to the builder.

## 1. Implement the documented but missing `.regex()` method

`.regex()` was documented in the README, advanced-usage guide, and FAQ, but it was never implemented. Any user copying the documented example hit a runtime crash:

```
TypeError: createRegex(...).regex is not a function
```

### What `.regex()` does

Splices an existing pattern into the chain so you can reuse a regex you already have:

```javascript
const basePattern = /^[A-Z]/;
createRegex().regex(basePattern).digit().exactly(3).toRegExp(); // /^[A-Z]\d{3}/
```

- Accepts a `RegExp` or a raw pattern string.
- Merges flags from a passed `RegExp` (e.g. `/abc/gi` carries `g` and `i` through).
- Treats input as a **pattern**, so metacharacters keep their regex meaning. To match text literally, use `.literal()`.
- Fails fast: an invalid pattern string throws immediately at the call site with a message pointing to `.literal()`, instead of a cryptic `SyntaxError` later at `.toRegExp()`.

| | Before | After |
|---|---|---|
| `createRegex().regex(/^[A-Z]/)` | `TypeError: ...regex is not a function` | `/^[A-Z]/` |
| `.regex("(")` | n/a | throws a descriptive error pointing to `.literal()` |

## 2. Fix `.repeat()` shifting capture-group indices

`.repeat(count)` wrapped the repeated pattern in a **capturing** group (`(...){n}`), which silently inserted an extra numbered group and shifted the numbering of the user's own capture groups.

```javascript
// before: repeat's hidden group steals index 1
createRegex().digit().repeat(2).startCaptureGroup().letter().oneOrMore().endGroup()
// source: (\d){2}([a-zA-Z]+)  ->  match[1] is a digit, not the letters
```

It now uses a **non-capturing** group (`(?:...){n}`), so it no longer disturbs the user's capture indices:

```javascript
// after
// source: (?:\d){2}([a-zA-Z]+)  ->  match[1] correctly holds the letters
```

## Testing

All tests pass with 100% statement/line coverage, including new tests for `.regex()` (RegExp input, string input, flag merging, invalid-input error, valid plain text) and for `.repeat()` not creating a capture group.
