### PR TITLE
fix: improve weak and incorrect prebuilt patterns (tld, email, url, phone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+<!-- TEMPLATE: copy the sections below into a new entry and replace the bracketed placeholders. -->
+
 ### Added
 
 - [Brief description of new features]
@@ -30,6 +32,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 - [Security-related updates]
+
+<!-- Current update -->
+
+### Changed
+
+- `.tld()` now matches any letters-based top-level domain by default
+  (`[a-zA-Z]{2,}`) instead of only `com|org|net`, and accepts an optional list to
+  restrict it, e.g. `.tld(["com", "org"])`.
+
+### Fixed
+
+- `Patterns.email` now accepts dots and plus-addressing in the local part
+  (e.g. `name.surname@example.com`, `user+tag@example.com`).
+- `Patterns.url` now accepts any top-level domain, subdomains, and an optional
+  query string, instead of rejecting valid URLs like `https://example.io`.
+- `Patterns.phoneInternational` now accepts a hyphen, a space, or no separator
+  after the country code.
+
+### Contributors
+
+- Hammed Abdulazeez (@lurdharry)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Creates a new regex builder instance.
 | `.protocol()` | Adds a protocol pattern (`https?://`). | `https?://`               |
 | `.www()`      | Adds a www pattern (`(www\.)?`).       | `(www\.)?`                |
 | `.path()`     | Adds a path pattern (`(/\w+)*`).       | `(/\w+)*`                 |
-| `.tld()`      | Adds a top-level domain pattern.       | \[\"\(com\|org\|net\)\"\] |
+| `.tld()`      | Adds a top-level domain pattern. Matches any letters TLD by default, or pass a list to restrict it, e.g. `.tld(["com", "org"])`. | `([a-zA-Z]{2,})` |
 
 ### Flags
 
@@ -166,9 +166,9 @@ Creates a new regex builder instance.
 
 ### Predefined Patterns
 
-- `Patterns.email`: Predefined email pattern.
-- `Patterns.url`: Predefined URL pattern.
-- `Patterns.phoneInternational`: Predefined international phone number pattern.
+- `Patterns.email`: Predefined email pattern. Allows dots and plus-addressing in the local part (e.g. `name.surname@example.com`, `user+tag@example.com`).
+- `Patterns.url`: Predefined URL pattern. Accepts any TLD, subdomains, and an optional query string.
+- `Patterns.phoneInternational`: Predefined international phone number pattern. Accepts a hyphen, a space, or no separator after the country code.
 
 ### Predefined Ranges
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,7 +121,7 @@ export class HumanRegex {
   ipv4Octet(): Base;
   protocol(): Base;
   www(): Base;
-  tld(): Base;
+  tld(list?: string[]): Base;
   path(): Base;
 
   toString(): string;

--- a/src/human-regex.ts
+++ b/src/human-regex.ts
@@ -281,8 +281,12 @@ class HumanRegex {
     return this.add("(www\\.)?");
   }
 
-  tld(): Base {
-    return this.add("(com|org|net)");
+  tld(list?: string[]): Base {
+    const body =
+      list && list.length
+        ? list.map((t) => escapeLiteral(t)).join("|")
+        : "[a-zA-Z]{2,}";
+    return this.add(`(${body})`);
   }
 
   path(): Base {
@@ -324,7 +328,7 @@ const Patterns = (() => {
     email: createCachedPattern(() =>
       createRegex()
         .startAnchor()
-        .word()
+        .anyOf("\\w.+-")
         .oneOrMore()
         .literal("@")
         .word()
@@ -345,11 +349,20 @@ const Patterns = (() => {
         .startAnchor()
         .protocol()
         .www()
-        .word()
+        .startGroup()
+        .anyOf("\\w-")
         .oneOrMore()
         .literal(".")
+        .endGroup()
+        .oneOrMore()
         .tld()
         .path()
+        .startGroup()
+        .literal("?")
+        .nonWhitespace()
+        .zeroOrMore()
+        .endGroup()
+        .optional()
         .endAnchor()
     ),
     phoneInternational: createCachedPattern(() =>
@@ -358,7 +371,8 @@ const Patterns = (() => {
         .literal("+")
         .digit()
         .between(1, 3)
-        .literal("-")
+        .anyOf("-\\s")
+        .optional()
         .digit()
         .between(3, 14)
         .endAnchor()

--- a/test/human-regex.test.ts
+++ b/test/human-regex.test.ts
@@ -411,12 +411,22 @@ test("path matches valid URL paths", () => {
   expect(regex.test("/invalid@path")).toBe(false);
 });
 
-test("tld matches valid top-level domains", () => {
+test("tld matches any letters-based top-level domain by default", () => {
   const regex = createRegex().startAnchor().tld().endAnchor().toRegExp();
   expect(regex.test("com")).toBe(true);
   expect(regex.test("net")).toBe(true);
   expect(regex.test("org")).toBe(true);
-  expect(regex.test("invalid")).toBe(false);
+  expect(regex.test("io")).toBe(true);
+  expect(regex.test("museum")).toBe(true);
+  expect(regex.test("a")).toBe(false); // needs at least 2 letters
+  expect(regex.test("12")).toBe(false); // digits are not a tld
+});
+
+test("tld restricts to a provided list when given one", () => {
+  const regex = createRegex().startAnchor().tld(["com", "org"]).endAnchor().toRegExp();
+  expect(regex.test("com")).toBe(true);
+  expect(regex.test("org")).toBe(true);
+  expect(regex.test("io")).toBe(false);
 });
 
 test("www matches optional www prefix", () => {
@@ -577,4 +587,30 @@ test("expect newline(s) to be detected properly", () => {
   expect(regex.test(`first line
 second line`)).toBe(true);
   expect(regex.test("test")).toBe(false);
+});
+
+test("email pattern accepts dots and plus-addressing in the local part", () => {
+  const regex = Patterns.email();
+  expect(regex.test("name.surname@example.com")).toBe(true);
+  expect(regex.test("user+tag@example.com")).toBe(true);
+  expect(regex.test("user@sub.example.co.uk")).toBe(true);
+  expect(regex.test("bad@@example.com")).toBe(false);
+  expect(regex.test("noatsign.com")).toBe(false);
+});
+
+test("url pattern accepts any tld, subdomains, and a query string", () => {
+  const regex = Patterns.url();
+  expect(regex.test("https://example.io")).toBe(true);
+  expect(regex.test("https://sub.example.org/a/b")).toBe(true);
+  expect(regex.test("https://example.com?q=1")).toBe(true);
+  expect(regex.test("http://www.example.com")).toBe(true);
+  expect(regex.test("ftp://example.com")).toBe(false);
+});
+
+test("phoneInternational accepts a space or hyphen separator or none", () => {
+  const regex = Patterns.phoneInternational;
+  expect(regex().test("+44 7911123456")).toBe(true);
+  expect(regex().test("+1-2025550123")).toBe(true);
+  expect(regex().test("+12025550123")).toBe(true);
+  expect(regex().test("12025550123")).toBe(false);
 });


### PR DESCRIPTION
## Summary

The prebuilt patterns and the `tld()` helper rejected a lot of valid, everyday input. This PR fixes `tld()`, `Patterns.email`, `Patterns.url`, and `Patterns.phoneInternational` so they accept real-world values, while keeping the invalid cases rejected.

## Changes

### `tld()` — matches any TLD by default

Previously hardcoded to `com|org|net`, so `Patterns.url()` rejected every other domain ending. It now matches any letters-based TLD by default, and accepts an optional list to restrict it.

```javascript
createRegex().tld().toString();               // ([a-zA-Z]{2,})  — any TLD
createRegex().tld(["com", "org"]).toString(); // (com|org)       — restricted
```

### `Patterns.email` — dots and plus-addressing

The local part now allows `.`, `+`, and `-`, not just word characters.

### `Patterns.url` — any TLD, subdomains, optional query

Accepts any TLD, multi-level subdomains, and an optional query string.

### `Patterns.phoneInternational` — flexible separator

Accepts a hyphen, a space, or no separator after the country code (the leading `+` is still required).

## Before / after

| Input | Before | After |
|---|---|---|
| `name.surname@example.com` | rejected | accepted |
| `user+tag@example.com` | rejected | accepted |
| `https://example.io` | rejected | accepted |
| `https://sub.example.org/a/b` | rejected | accepted |
| `https://example.com?q=1` | rejected | accepted |
| `+44 7911123456` | rejected | accepted |
| `+12025550123` | rejected | accepted |
| `bad@@example.com` | rejected | rejected |
| `ftp://example.com` | rejected | rejected |
| `12025550123` (no `+`) | rejected | rejected |

## Notes

- `.tld()`'s default output changes from `(com|org|net)` to `([a-zA-Z]{2,})` — a behavior change, noted in the changelog. Callers who want the old restriction can use `.tld(["com", "org", "net"])`.
- List entries passed to `.tld([...])` are escaped, so special characters can't break the pattern.

## Testing

All 66 tests pass with 100% statement/line coverage, including new tests for each improved pattern and the `tld()` restrict list.
